### PR TITLE
docs: fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Tired of making your gazillionth chunker? Sick of the overhead of large librarie
 **⚡ Fast**: CHONK at the speed of light! zooooom </br>
 **🪶 Light-weight**: No bloat, just CHONK </br>
 **🌏 Wide support**: CHONKie [integrates](#integrations) with your favorite tokenizer, embedding model and APIs! </br>
-**💬 ️Multilingual**: Out-of-the-box support for 56 languages </br>
+**💬 Multilingual**: Out-of-the-box support for 56 languages </br>
 **☁️ Cloud-Ready**: CHONK locally or in the [Chonkie Cloud](https://cloud.chonkie.ai) </br>
 **🦛 Cute CHONK mascot**: psst it's a pygmy hippo btw </br>
 **❤️ [Moto Moto](#acknowledgements)'s favorite python library** </br>


### PR DESCRIPTION
Fixed a minor typo in the README.md file by removing an unnecessary space

This is a small documentation cleanup, no functionality or code was changed
